### PR TITLE
Dark mode and other style improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         mv render/* .
         mv rendered.html index.html
         git checkout -b deploy-temp
-        git add index.html favicon.ico
+        git add index.html favicon.ico plot.js style.css
         git commit -m "Deployed on $(date -u '+%Y-%m-%d %H:%M:%S')"
         git push -f origin deploy-temp:deploy
         git checkout main

--- a/render.py
+++ b/render.py
@@ -94,14 +94,14 @@ def to_html(
 
     tests_table = """
 <tr>
-    <th style="border: 1px solid black;">Test Name</th>
+    <th>Test Name</th>
 """
     instruments = sorted(set(INSTRUMENTS) - {"none"})
     for instr in instruments:
-        tests_table += f'            <th style="border: 1px solid black;">{instr}</th>\n'
+        tests_table += f'            <th>{instr}</th>\n'
     tests_table += f'        <tr>\n            <td colspan="{len(INSTRUMENTS)}" ">&nbsp;</td>\n        </tr>\n'
     for i, group in enumerate(GROUPS):
-        tests_table += f'        <tr>\n            <td colspan="{len(INSTRUMENTS)}" style="border: 1px solid black;background-color: #D3D3D3;font-size: 1.5em;"><b>{group}</b></td>\n'
+        tests_table += f'        <tr>\n            <td colspan="{len(INSTRUMENTS)}" class="group-header"><b>{group}</b></td>\n'
         tests_table += "        </tr>\n"
         for test_name, instr_map in test_map[group].items():
             # Find max number of tests
@@ -109,13 +109,13 @@ def to_html(
             for ins in INSTRUMENTS:
                 if ins in instr_map:
                     max_tests = max(max_tests, len(instr_map[ins]))
-            tests_table += f'        <tr>\n            <td rowspan="{max_tests}" style="border: 1px solid black;">{test_name.replace("_", " ")}</td>\n'
+            tests_table += f'        <tr>\n            <td rowspan="{max_tests}">{test_name.replace("_", " ")}</td>\n'
             if "none" in instr_map:
                 for i in range(max_tests):
                     if i > 0:
                         tests_table += "        <tr>\n"
                     if i >= len(instr_map["none"]):
-                        tests_table += f'            <td colspan="{len(INSTRUMENTS)}" style="border: 1px solid black;"></td></tr>\n'
+                        tests_table += f'            <td colspan="{len(INSTRUMENTS)}"></td></tr>\n'
                     else:
                         text, status, url = instr_map["none"][i]
                         if len(text) > 16:
@@ -123,7 +123,7 @@ def to_html(
                         if not text:
                             text = "&nbsp;"
                         tests_table += (
-                            f'<td colspan="{len(INSTRUMENTS)}" class="{status}" style="border: 1px solid black;">'
+                            f'<td colspan="{len(INSTRUMENTS)}" class="{status}">'
                             f'<a href="{url}" style="text-decoration:none;display: block; width: 100%; height: 100%;">{text}</a></td></tr>\n'
                         )
             else:
@@ -132,10 +132,10 @@ def to_html(
                         tests_table += "        <tr>\n"
                     for ins in instruments:
                         if ins not in instr_map:
-                            tests_table += '            <td style="border: 1px solid black;"></td>\n'
+                            tests_table += '            <td></td>\n'
                         else:
                             if i >= len(instr_map[ins]):
-                                tests_table += '            <td style="border: 1px solid black;"></td>\n'
+                                tests_table += '            <td></td>\n'
                             else:
                                 text, status, url = instr_map[ins][i]
                                 if len(text) > 16:
@@ -143,8 +143,8 @@ def to_html(
                                 if not text:
                                     text = "&nbsp;"
                                 tests_table += (
-                                    f'<td class="{status}" style="border: 1px solid black;">'
-                                    f'<a href="{url}" style="text-decoration:none;display: block; width: 100%; height: 100%;">{text}</a></td>\n'
+                                    f'<td class="{status}">'
+                                    f'<a href="{url}">{text}</a></td>\n'
                                 )
                     tests_table += "        </tr>\n"
         tests_table += f'        <tr>\n            <td colspan="{len(INSTRUMENTS)}" ">&nbsp;</td>\n        </tr>\n'

--- a/render.py
+++ b/render.py
@@ -83,7 +83,7 @@ def load_main_template():
 
 def to_html(
     test_map,
-    failing_test,
+    failing_tests,
     skipped_tests,
     passing_tests,
     dates,
@@ -151,66 +151,15 @@ def to_html(
         tests_table += f'        <tr>\n            <td colspan="{len(INSTRUMENTS)}" ">&nbsp;</td>\n        </tr>\n'
 
     # Add plotly chart with test history
-    plotly_script = f"""
-var dates = {dates};
-var failing_test = {failing_test};
-var skipped_tests = {skipped_tests};
-var passing_tests = {passing_tests};
-var data = [
-    {{
-        x: dates,
-        y: failing_test,
-        type: 'scatter',
-        mode: 'lines+markers',
-        name: 'Failed Tests',
-        marker: {{color: 'red'}}
-    }},
-    {{
-        x: dates,
-        y: skipped_tests,
-        type: 'scatter',
-        mode: 'lines+markers',
-        name: 'Skipped Tests',
-        marker: {{color: 'orange'}}
-    }},
-    {{
-        x: dates,
-        y: passing_tests,
-        type: 'scatter',
-        mode: 'lines+markers',
-        name: 'Passed Tests',
-        marker: {{color: 'green'}}
-    }}
-];
-var layout = {{
-    title: {{
-        text: 'Test History',
-    }},
-    yaxis: {{
-        title: {{
-            text: 'Number of Tests'
-        }}
-    }},
-    showlegend: true,
-    legend: {{
-        x: 1,
-        y: 1,
-        xanchor: 'right',
-        yanchor: 'bottom',
-        orientation: 'h',
-    }},
-    paper_bgcolor: 'rgba(255,255,255, 0)',
-    plot_bgcolor: 'rgba(255,255,255, 0)',
-}};
-Plotly.newPlot('chart', data, layout);
-"""
+    plotly_script = f"historyChart({dates}, {failing_tests}, {skipped_tests}, {passing_tests});"
+    # Add plotly chart with test groups
     for group in GROUPS:
         plotly_script += f"var group_{group.replace('-', '_')} = {groups_chart[group]};\n"
     plotly_script += "var data_groups = [\n"
     for group in GROUPS:
         plotly_script += f"""
     {{
-        x: dates,
+        x: {dates},
         y: group_{group.replace("-", "_")},
         type: 'scatter',
         mode: 'lines+markers',
@@ -218,31 +167,7 @@ Plotly.newPlot('chart', data, layout);
     }},
 """
     plotly_script += "];\n"
-    plotly_script += """
-var layout_groups = {
-    title: {
-        text: 'Success Rate by Group',
-    },
-    yaxis: {
-        title: {
-            text: 'Success Rate',
-        },
-        range: [0, 105],
-    },
-    showlegend: true,
-    legend: {
-        x: 1,
-        y: -0.2,
-        xanchor: 'right',
-        yanchor: 'top',
-        orientation: 'h',
-    },
-    paper_bgcolor: 'rgba(255,255,255, 0)',
-    plot_bgcolor: 'rgba(255,255,255, 0)',
-};
-Plotly.newPlot('groups_chart', data_groups, layout_groups);
-</script>
-"""
+    plotly_script += "groupsChart(data_groups);"
 
     return main_html.format(
         last_updated=last_updated,
@@ -333,7 +258,7 @@ def main():
 
     percentage_data = [i[2] for i in run_chart]
     failed_job_percentage = f"{percentage_data[-1]:.2f}%"
-    failing_test = [i[3] for i in run_chart]
+    failing_tests = [i[3] for i in run_chart]
     skipped_tests = [i[4] for i in run_chart]
     passing_tests = [i[5] for i in run_chart]
     dates = [i[6] for i in run_chart]
@@ -380,7 +305,7 @@ def main():
 
     content = to_html(
         global_map,
-        failing_test=failing_test,
+        failing_tests=failing_tests,
         skipped_tests=skipped_tests,
         passing_tests=passing_tests,
         dates=dates,

--- a/render.py
+++ b/render.py
@@ -2,6 +2,7 @@ import os
 import logging
 from datetime import datetime, timedelta
 from dataclasses import dataclass
+from pathlib import Path
 from urllib.parse import quote
 
 import requests
@@ -76,12 +77,8 @@ def get_test_report(project_id, pipeline_id):
     return response.json()
 
 
-color_map = {
-    "success": "rgba(0, 128, 0, 0.5)",
-    "failed": "rgba(255, 0, 0, 0.5)",
-    "skipped": "rgba(255, 165, 0, 0.5)",
-    "error": "white",
-}
+def load_main_template():
+    return Path(__file__).resolve().parent.joinpath("templates", "main.html").read_text()
 
 
 def to_html(
@@ -92,113 +89,69 @@ def to_html(
     dates,
     groups_chart,
 ):
-    html = """<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="3600">
-    <link rel="icon" href="favicon.ico" type="image/x-icon">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>DMSC Integration Testing</title>
-    <script src="https://cdn.plot.ly/plotly-3.0.1.min.js" charset="utf-8"></script>
-</head>
-<body style="font-family: Tahoma, sans-serif; border:0; margin:0;">
-<div style="width: 100%; display: flex; height: 80px;">
-<div style="flex:0.3;">
-    <img src="https://ess.eu/themes/custom/ess/logo.svg" alt="Logo" height="80">
-</div>
-<div style="flex:1; text-align: center; color: white; background-color: #0094ca;">
-    <h1><b>DMSC Integration Testing</b></h1>
-</div>
-<div style="flex:1; text-align:right; color: white; background-color: #0094ca;">
-    <h3>Last updated: """
-    html += datetime.now().strftime("%B %d, %Y %I:%M %p")
-    html += """</h3>
-</div>
-</div>
-<div style="width: 100%;">
-    <table style="border-collapse: collapse;">
-            <tr>
-                <td style="width: 60%;vertical-align: top;">
-    <br>
-    """
-    # Add colored rectangles for legend
-    html += (
-        f"Key: &nbsp;&nbsp;&nbsp;&nbsp; <div style='display:inline-block; width: 20px; height: 20px; background-color: {color_map['success']};'></div> "
-        f"= Success &nbsp;&nbsp;&nbsp;&nbsp; <div style='display:inline-block; width: 20px; height: 20px; background-color: {color_map['failed']};'></div> "
-        f"= Failed &nbsp;&nbsp;&nbsp;&nbsp; <div style='display:inline-block; width: 20px; height: 20px; background-color: {color_map['skipped']};'></div> = Skipped"
-    )
-    html += """<br><br>
-    <table style="border-collapse: collapse;">
-        <tr>
-            <th style="border: 1px solid black;">Test Name</th>
+    main_html = load_main_template()
+    last_updated = datetime.now().strftime("%B %d, %Y %I:%M %p")
+
+    tests_table = """
+<tr>
+    <th style="border: 1px solid black;">Test Name</th>
 """
     instruments = sorted(set(INSTRUMENTS) - {"none"})
     for instr in instruments:
-        html += f'            <th style="border: 1px solid black;">{instr}</th>\n'
-    html += f'        <tr>\n            <td colspan="{len(INSTRUMENTS)}" ">&nbsp;</td>\n        </tr>\n'
+        tests_table += f'            <th style="border: 1px solid black;">{instr}</th>\n'
+    tests_table += f'        <tr>\n            <td colspan="{len(INSTRUMENTS)}" ">&nbsp;</td>\n        </tr>\n'
     for i, group in enumerate(GROUPS):
-        html += f'        <tr>\n            <td colspan="{len(INSTRUMENTS)}" style="border: 1px solid black;background-color: #D3D3D3;font-size: 1.5em;"><b>{group}</b></td>\n'
-        html += "        </tr>\n"
+        tests_table += f'        <tr>\n            <td colspan="{len(INSTRUMENTS)}" style="border: 1px solid black;background-color: #D3D3D3;font-size: 1.5em;"><b>{group}</b></td>\n'
+        tests_table += "        </tr>\n"
         for test_name, instr_map in test_map[group].items():
             # Find max number of tests
             max_tests = 0
             for ins in INSTRUMENTS:
                 if ins in instr_map:
                     max_tests = max(max_tests, len(instr_map[ins]))
-            html += f'        <tr>\n            <td rowspan="{max_tests}" style="border: 1px solid black;">{test_name.replace("_", " ")}</td>\n'
+            tests_table += f'        <tr>\n            <td rowspan="{max_tests}" style="border: 1px solid black;">{test_name.replace("_", " ")}</td>\n'
             if "none" in instr_map:
                 for i in range(max_tests):
                     if i > 0:
-                        html += "        <tr>\n"
+                        tests_table += "        <tr>\n"
                     if i >= len(instr_map["none"]):
-                        html += f'            <td colspan="{len(INSTRUMENTS)}" style="border: 1px solid black;"></td></tr>\n'
+                        tests_table += f'            <td colspan="{len(INSTRUMENTS)}" style="border: 1px solid black;"></td></tr>\n'
                     else:
                         text, status, url = instr_map["none"][i]
                         if len(text) > 16:
                             text = text[:16] + "..."
                         if not text:
                             text = "&nbsp;"
-                        html += (
-                            f'<td colspan="{len(INSTRUMENTS)}" style="border: 1px solid black; background-color: {color_map[status]};">'
+                        tests_table += (
+                            f'<td colspan="{len(INSTRUMENTS)}" class="{status}" style="border: 1px solid black;">'
                             f'<a href="{url}" style="text-decoration:none;display: block; width: 100%; height: 100%;">{text}</a></td></tr>\n'
                         )
             else:
                 for i in range(max_tests):
                     if i > 0:
-                        html += "        <tr>\n"
+                        tests_table += "        <tr>\n"
                     for ins in instruments:
                         if ins not in instr_map:
-                            html += f'            <td style="border: 1px solid black; background-color: {color_map["error"]};"></td>\n'
+                            tests_table += '            <td style="border: 1px solid black;"></td>\n'
                         else:
                             if i >= len(instr_map[ins]):
-                                html += f'            <td style="border: 1px solid black; background-color: {color_map["error"]};"></td>\n'
+                                tests_table += '            <td style="border: 1px solid black;"></td>\n'
                             else:
                                 text, status, url = instr_map[ins][i]
                                 if len(text) > 16:
                                     text = text[:16] + "..."
                                 if not text:
                                     text = "&nbsp;"
-                                html += (
-                                    f'<td style="border: 1px solid black; background-color: {color_map[status]};">'
-                                    f'<a href="{url}" style="text-decoration:none;display: block; width: 100%; height: 100%; color: black;">{text}</a></td>\n'
+                                tests_table += (
+                                    f'<td class="{status}" style="border: 1px solid black;">'
+                                    f'<a href="{url}" style="text-decoration:none;display: block; width: 100%; height: 100%;">{text}</a></td>\n'
                                 )
-                    html += "        </tr>\n"
-        html += f'        <tr>\n            <td colspan="{len(INSTRUMENTS)}" ">&nbsp;</td>\n        </tr>\n'
-        html += f'        <tr>\n            <td colspan="{len(INSTRUMENTS)}" ">&nbsp;</td>\n        </tr>\n'
-    html += """    </table>
-</td>
-<td style=" width: 40%; vertical-align: top;">
-"""
+                    tests_table += "        </tr>\n"
+        tests_table += f'        <tr>\n            <td colspan="{len(INSTRUMENTS)}" ">&nbsp;</td>\n        </tr>\n'
+        tests_table += f'        <tr>\n            <td colspan="{len(INSTRUMENTS)}" ">&nbsp;</td>\n        </tr>\n'
 
     # Add plotly chart with test history
-    chart = f"""
-    <div id="chart"></div>
-    <div id="groups_chart"></div>
-</td>
-</tr>
-</table>
-<script>
+    plotly_script = f"""
 var dates = {dates};
 var failing_test = {failing_test};
 var skipped_tests = {skipped_tests};
@@ -245,15 +198,17 @@ var layout = {{
         xanchor: 'right',
         yanchor: 'bottom',
         orientation: 'h',
-    }}
+    }},
+    paper_bgcolor: 'rgba(255,255,255, 0)',
+    plot_bgcolor: 'rgba(255,255,255, 0)',
 }};
 Plotly.newPlot('chart', data, layout);
 """
     for group in GROUPS:
-        chart += f"var group_{group.replace('-', '_')} = {groups_chart[group]};\n"
-    chart += "var data_groups = [\n"
+        plotly_script += f"var group_{group.replace('-', '_')} = {groups_chart[group]};\n"
+    plotly_script += "var data_groups = [\n"
     for group in GROUPS:
-        chart += f"""
+        plotly_script += f"""
     {{
         x: dates,
         y: group_{group.replace("-", "_")},
@@ -262,8 +217,8 @@ Plotly.newPlot('chart', data, layout);
         name: '{group}',
     }},
 """
-    chart += "];\n"
-    chart += """
+    plotly_script += "];\n"
+    plotly_script += """
 var layout_groups = {
     title: {
         text: 'Success Rate by Group',
@@ -282,17 +237,18 @@ var layout_groups = {
         yanchor: 'top',
         orientation: 'h',
     },
+    paper_bgcolor: 'rgba(255,255,255, 0)',
+    plot_bgcolor: 'rgba(255,255,255, 0)',
 };
 Plotly.newPlot('groups_chart', data_groups, layout_groups);
 </script>
 """
-    html += chart
 
-    html += """
-</div>
-</body>
-</html>"""
-    return html
+    return main_html.format(
+        last_updated=last_updated,
+        tests_table=tests_table,
+        plotly_script=plotly_script
+    )
 
 
 def main():

--- a/render.py
+++ b/render.py
@@ -93,13 +93,14 @@ def to_html(
     last_updated = datetime.now().strftime("%B %d, %Y %I:%M %p")
 
     tests_table = """
-<tr>
+<thead>
+<tr class="tests-table-header">
     <th>Test Name</th>
 """
     instruments = sorted(set(INSTRUMENTS) - {"none"})
     for instr in instruments:
         tests_table += f'            <th>{instr}</th>\n'
-    tests_table += f'        <tr>\n            <td colspan="{len(INSTRUMENTS)}" ">&nbsp;</td>\n        </tr>\n'
+    tests_table += f'        <tr></thead></tbody>\n            <td colspan="{len(INSTRUMENTS)}" ">&nbsp;</td>\n        </tr>\n'
     for i, group in enumerate(GROUPS):
         tests_table += f'        <tr>\n            <td colspan="{len(INSTRUMENTS)}" class="group-header"><b>{group}</b></td>\n'
         tests_table += "        </tr>\n"
@@ -147,8 +148,8 @@ def to_html(
                                     f'<a href="{url}">{text}</a></td>\n'
                                 )
                     tests_table += "        </tr>\n"
-        tests_table += f'        <tr>\n            <td colspan="{len(INSTRUMENTS)}" ">&nbsp;</td>\n        </tr>\n'
-        tests_table += f'        <tr>\n            <td colspan="{len(INSTRUMENTS)}" ">&nbsp;</td>\n        </tr>\n'
+        tests_table += f'        <tr>\n            <td colspan="{len(INSTRUMENTS)}" class="row-gap">&nbsp;</td>\n        </tr>\n' * 2
+    tests_table += '</tbody>'
 
     # Add plotly chart with test history
     plotly_script = f"historyChart({dates}, {failing_tests}, {skipped_tests}, {passing_tests});"

--- a/render/plot.js
+++ b/render/plot.js
@@ -1,0 +1,74 @@
+function historyChart(dates, failing_tests, skipped_tests, passing_tests) {
+  var data = [
+      {
+          x: dates,
+          y: failing_tests,
+          type: 'scatter',
+          mode: 'lines+markers',
+          name: 'Failed Tests',
+          marker: {color: 'red'}
+      },
+      {
+          x: dates,
+          y: skipped_tests,
+          type: 'scatter',
+          mode: 'lines+markers',
+          name: 'Skipped Tests',
+          marker: {color: 'orange'}
+      },
+      {
+          x: dates,
+          y: passing_tests,
+          type: 'scatter',
+          mode: 'lines+markers',
+          name: 'Passed Tests',
+          marker: {color: 'green'}
+      }
+  ];
+  var layout = {
+      title: {
+          text: 'Test History',
+      },
+      yaxis: {
+          title: {
+              text: 'Number of Tests'
+          }
+      },
+      showlegend: true,
+      legend: {
+          x: 1,
+          y: 1,
+          xanchor: 'right',
+          yanchor: 'bottom',
+          orientation: 'h',
+      },
+      paper_bgcolor: 'rgba(255,255,255, 0)',
+      plot_bgcolor: 'rgba(255,255,255, 0)',
+  };
+  Plotly.newPlot('history_chart', data, layout);
+}
+
+function groupsChart(data_groups) {
+  var layout_groups = {
+      title: {
+          text: 'Success Rate by Group',
+      },
+      yaxis: {
+          title: {
+              text: 'Success Rate',
+          },
+          range: [0, 105],
+      },
+      showlegend: true,
+      legend: {
+          x: 1,
+          y: -0.2,
+          xanchor: 'right',
+          yanchor: 'top',
+          orientation: 'h',
+      },
+      paper_bgcolor: 'rgba(255,255,255, 0)',
+      plot_bgcolor: 'rgba(255,255,255, 0)',
+  };
+  Plotly.newPlot('groups_chart', data_groups, layout_groups);
+}

--- a/render/style.css
+++ b/render/style.css
@@ -80,6 +80,16 @@ main {
     font-size: 1.5em;
 }
 
+.table-legend {
+    display: flex;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.table-legend div {
+    margin-right: 5pt;
+}
+
 .success {
     background: var(--success-bg);
 }

--- a/render/style.css
+++ b/render/style.css
@@ -1,59 +1,27 @@
 :root {
-	--gray-1: #111111;
-	--gray-2: #191919;
-	--gray-3: #222222;
-	--gray-4: #2a2a2a;
-	--gray-5: #313131;
-	--gray-6: #3a3a3a;
-	--gray-7: #484848;
-	--gray-8: #606060;
-	--gray-9: #6e6e6e;
-	--gray-10: #7b7b7b;
-	--gray-11: #b4b4b4;
-	--gray-12: #eeeeee;
+    /* Colors are based on the radix scales at
+         https://www.radix-ui.com/colors/docs/palette-composition/scales
+       Comments show the specific scale name and index.
+    */
+    --background-1: light-dark(#fff7f7, #201314);  /* gray-2 */
+    --background-2: light-dark(#e0e0e0, #313131);  /* gray-5 */
+    --text-1: light-dark(#202020, #eeeeee);  /* gray-12 */
+    --border: light-dark(#bbbbbb, #606060);  /* gray-8 */
 
-	--red-1: #191111;
-	--red-2: #201314;
-	--red-3: #3b1219;
-	--red-4: #500f1c;
-	--red-5: #611623;
-	--red-6: #72232d;
-	--red-7: #8c333a;
-	--red-8: #b54548;
-	--red-9: #e5484d;
-	--red-10: #ec5d5e;
-	--red-11: #ff9592;
-	--red-12: #ffd1d9;
-
-	--yellow-1: #14120b;
-	--yellow-2: #1b180f;
-	--yellow-3: #2d2305;
-	--yellow-4: #362b00;
-	--yellow-5: #433500;
-	--yellow-6: #524202;
-	--yellow-7: #665417;
-	--yellow-8: #836a21;
-	--yellow-9: #ffe629;
-	--yellow-10: #ffff57;
-	--yellow-11: #f5e147;
-	--yellow-12: #f6eeb4;
-
-	--green-1: #0e1512;
-	--green-2: #121b17;
-	--green-3: #132d21;
-	--green-4: #113b29;
-	--green-5: #174933;
-	--green-6: #20573e;
-	--green-7: #28684a;
-	--green-8: #2f7c57;
-	--green-9: #30a46c;
-	--green-10: #33b074;
-	--green-11: #3dd68c;
-	--green-12: #b1f1cb;
+    --success-fg:  light-dark(#fbfefb, #0e1511);  /* grass-1 */
+    --success-bg: light-dark(#46a758, #46a758);  /* grass-9 */
+    --success-bg-hover: light-dark(#3e9b4f, #53b365);  /* grass-10 */
+    --failed-fg: light-dark(#fffcfc, #191111);  /* red-1 */
+    --failed-bg: light-dark(#e5484d, #e5484d);  /* red-9 */
+    --failed-bg-hover: light-dark(#dc3e42, #ec5d5e);  /* red-10 */
+    --skipped-fg: light-dark(#4f3422, #16120c);  /* (amber-12, amber-1) */
+    --skipped-bg: light-dark(#ffc53d, #ffc53d);  /* amber-9 */
+    --skipped-bg-hover: light-dark(#ffba18, #ffd60a);  /* amber-10 */
 }
 
 body {
-    background: var(--gray-2);
+    background: var(--background-1);
+    color: var(text-1);
 }
 
 header {
@@ -71,39 +39,39 @@ main {
 }
 
 .success {
-    background: var(--green-9);
+    background: var(--success-bg);
 }
 
 .success a, .success a:visited {
-    color: var(--green-1);
+    color: var(--success-fg);
 }
 
 .success:hover {
-    background: var(--green-10);
+    background: var(--success-bg-hover);
 }
 
 .failed {
-    background: var(--red-9);
+    background: var(--failed-bg);
 }
 
 .failed a, .failed a:visited {
-    color: var(--red-1);
+    color: var(--failed-fg);
 }
 
 .failed:hover {
-    background: var(--red-10);
+    background: var(--failed-bg-hover);
 }
 
 .skipped {
-    background: var(--yellow-9);
+    background: var(--skipped-bg);
 }
 
 .skipped a, .skipped a:visited {
-    color: var(--yellow-1);
+    color: var(--skipped-fg);
 }
 
 .skipped:hover {
-    background: var(--yellow-10);
+    background: var(--skipped-bg-hover);
 }
 
 .tests-table {
@@ -111,7 +79,7 @@ main {
 }
 
 .tests-table td, .tests-table th {
-    border: 1px solid var(--gray-8);
+    border: 1px solid var(--border);
 }
 
 .tests-table a {
@@ -122,10 +90,13 @@ main {
 }
 
 .group-header {
-    background-color: var(--gray-5);
+    background-color: var(--background-2);
     font-size: 1.5em;
 }
 
-.plot-container {
-    filter: invert(75%) hue-rotate(180deg);
+/* make plots dark */
+@media(prefers-color-scheme: dark) {
+    .plot-container {
+        filter: invert(75%) hue-rotate(180deg);
+    }
 }

--- a/render/style.css
+++ b/render/style.css
@@ -1,4 +1,17 @@
 :root {
+	--gray-1: #111111;
+	--gray-2: #191919;
+	--gray-3: #222222;
+	--gray-4: #2a2a2a;
+	--gray-5: #313131;
+	--gray-6: #3a3a3a;
+	--gray-7: #484848;
+	--gray-8: #606060;
+	--gray-9: #6e6e6e;
+	--gray-10: #7b7b7b;
+	--gray-11: #b4b4b4;
+	--gray-12: #eeeeee;
+
 	--red-1: #191111;
 	--red-2: #201314;
 	--red-3: #3b1219;
@@ -39,12 +52,34 @@
 	--green-12: #b1f1cb;
 }
 
+body {
+    background: var(--gray-2);
+}
+
+header {
+    width: 100%;
+    height: 100px;
+    display: flex;
+}
+
+main {
+    margin: 10pt;
+}
+
+.logo {
+    padding: 10px;
+}
+
 .success {
     background: var(--green-9);
 }
 
 .success a, .success a:visited {
     color: var(--green-1);
+}
+
+.success:hover {
+    background: var(--green-10);
 }
 
 .failed {
@@ -55,12 +90,40 @@
     color: var(--red-1);
 }
 
+.failed:hover {
+    background: var(--red-10);
+}
+
 .skipped {
     background: var(--yellow-9);
 }
 
 .skipped a, .skipped a:visited {
     color: var(--yellow-1);
+}
+
+.skipped:hover {
+    background: var(--yellow-10);
+}
+
+.tests-table {
+    border-collapse: collapse;
+}
+
+.tests-table td, .tests-table th {
+    border: 1px solid var(--gray-8);
+}
+
+.tests-table a {
+    text-decoration:none;
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
+.group-header {
+    background-color: var(--gray-5);
+    font-size: 1.5em;
 }
 
 .plot-container {

--- a/render/style.css
+++ b/render/style.css
@@ -38,6 +38,48 @@ main {
     padding: 10px;
 }
 
+.tests-table {
+    border-collapse: collapse;
+}
+
+.tests-table td, .tests-table th {
+    border: 1px solid var(--border);
+}
+
+.tests-table td.row-gap {
+    border: none;
+}
+
+.tests-table a {
+    text-decoration:none;
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
+/* make header stick to the top of the page */
+.tests-table thead th {
+    position: sticky;
+    top: -1px;
+    
+    /* the border does not stick with the element, so emulate a sticking border */
+    box-shadow: 1px 1px 0 var(--border), -1px -1px 0 var(--border);
+    border: none;
+    
+    background-color: var(--background-2);
+    font-size: 1.2em;
+}
+
+.tests-table thead {
+    /* fill little gaps left by shadow */
+    border: 1px solid var(--border);
+}
+
+.group-header {
+    background-color: var(--background-2);
+    font-size: 1.5em;
+}
+
 .success {
     background: var(--success-bg);
 }
@@ -72,26 +114,6 @@ main {
 
 .skipped:hover {
     background: var(--skipped-bg-hover);
-}
-
-.tests-table {
-    border-collapse: collapse;
-}
-
-.tests-table td, .tests-table th {
-    border: 1px solid var(--border);
-}
-
-.tests-table a {
-    text-decoration:none;
-    display: block;
-    width: 100%;
-    height: 100%;
-}
-
-.group-header {
-    background-color: var(--background-2);
-    font-size: 1.5em;
 }
 
 /* make plots dark */

--- a/render/style.css
+++ b/render/style.css
@@ -1,0 +1,68 @@
+:root {
+	--red-1: #191111;
+	--red-2: #201314;
+	--red-3: #3b1219;
+	--red-4: #500f1c;
+	--red-5: #611623;
+	--red-6: #72232d;
+	--red-7: #8c333a;
+	--red-8: #b54548;
+	--red-9: #e5484d;
+	--red-10: #ec5d5e;
+	--red-11: #ff9592;
+	--red-12: #ffd1d9;
+
+	--yellow-1: #14120b;
+	--yellow-2: #1b180f;
+	--yellow-3: #2d2305;
+	--yellow-4: #362b00;
+	--yellow-5: #433500;
+	--yellow-6: #524202;
+	--yellow-7: #665417;
+	--yellow-8: #836a21;
+	--yellow-9: #ffe629;
+	--yellow-10: #ffff57;
+	--yellow-11: #f5e147;
+	--yellow-12: #f6eeb4;
+
+	--green-1: #0e1512;
+	--green-2: #121b17;
+	--green-3: #132d21;
+	--green-4: #113b29;
+	--green-5: #174933;
+	--green-6: #20573e;
+	--green-7: #28684a;
+	--green-8: #2f7c57;
+	--green-9: #30a46c;
+	--green-10: #33b074;
+	--green-11: #3dd68c;
+	--green-12: #b1f1cb;
+}
+
+.success {
+    background: var(--green-9);
+}
+
+.success a, .success a:visited {
+    color: var(--green-1);
+}
+
+.failed {
+    background: var(--red-9);
+}
+
+.failed a, .failed a:visited {
+    color: var(--red-1);
+}
+
+.skipped {
+    background: var(--yellow-9);
+}
+
+.skipped a, .skipped a:visited {
+    color: var(--yellow-1);
+}
+
+.plot-container {
+    filter: invert(75%) hue-rotate(180deg);
+}

--- a/templates/main.html
+++ b/templates/main.html
@@ -25,13 +25,21 @@
     </header>
     <main style="width: 100%;">
         <table style="border-collapse: collapse;">
+            <thead>
             <tr>
-                <td style="width: 60%;vertical-align: top;">
+                <th class="table-legend" style="width: 60%;">
                     <br>
                     Key: &nbsp;&nbsp;&nbsp;&nbsp; <div class='success' style='display:inline-block; width: 20px; height: 20px;'></div>
                     = Success &nbsp;&nbsp;&nbsp;&nbsp; <div class='failed' style='display:inline-block; width: 20px; height: 20px;'></div>
                     = Failed &nbsp;&nbsp;&nbsp;&nbsp; <div class='skipped' style='display:inline-block; width: 20px; height: 20px;'></div> = Skipped
                     <br><br>
+                </th>
+                <th style=" width: 40%;"></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td style="width: 60%; vertical-align: top;">
                     <table class="tests-table">
                         {tests_table}
                     </table>
@@ -41,6 +49,7 @@
                     <div id="groups_chart"></div>
                 </td>
             </tr>
+            </tbody>
         </table>
         <script>{plotly_script}</script>
     </main>

--- a/templates/main.html
+++ b/templates/main.html
@@ -12,8 +12,8 @@
 <script src="plot.js"></script>
 </head>
 <body style="font-family: Tahoma, sans-serif; border:0; margin:0;">
-    <div style="width: 100%; display: flex; height: 80px;">
-        <div style="flex:0.3;">
+    <header>
+        <div class="logo" style="flex:0.3;">
             <img src="https://ess.eu/themes/custom/ess/logo.svg" alt="Logo" height="80">
         </div>
         <div style="flex:1; text-align: center; color: white; background-color: #0094ca;">
@@ -22,8 +22,8 @@
         <div style="flex:1; text-align:right; color: white; background-color: #0094ca;">
             <h3>Last updated: {last_updated}</h3>
         </div>
-    </div>
-    <div style="width: 100%;">
+    </header>
+    <main style="width: 100%;">
         <table style="border-collapse: collapse;">
             <tr>
                 <td style="width: 60%;vertical-align: top;">
@@ -32,7 +32,7 @@
                     = Success &nbsp;&nbsp;&nbsp;&nbsp; <div class='failed' style='display:inline-block; width: 20px; height: 20px;'></div>
                     = Failed &nbsp;&nbsp;&nbsp;&nbsp; <div class='skipped' style='display:inline-block; width: 20px; height: 20px;'></div> = Skipped
                     <br><br>
-                    <table style="border-collapse: collapse;">
+                    <table class="tests-table">
                         {tests_table}
                     </table>
                 </td>
@@ -43,6 +43,6 @@
             </tr>
         </table>
         <script>{plotly_script}</script>
-    </div>
+    </main>
 </body>
 </html>

--- a/templates/main.html
+++ b/templates/main.html
@@ -7,8 +7,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="color-scheme" content="light dark">
 <title>DMSC Integration Testing</title>
-<script src="https://cdn.plot.ly/plotly-3.0.1.min.js" charset="utf-8"></script>
 <link rel="stylesheet" href="style.css">
+<script src="https://cdn.plot.ly/plotly-3.0.1.min.js" charset="utf-8"></script>
+<script src="plot.js"></script>
 </head>
 <body style="font-family: Tahoma, sans-serif; border:0; margin:0;">
     <div style="width: 100%; display: flex; height: 80px;">
@@ -36,7 +37,7 @@
                     </table>
                 </td>
                 <td style=" width: 40%; vertical-align: top;">
-                    <div id="chart"></div>
+                    <div id="history_chart"></div>
                     <div id="groups_chart"></div>
                 </td>
             </tr>

--- a/templates/main.html
+++ b/templates/main.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="refresh" content="3600">
+<link rel="icon" href="favicon.ico" type="image/x-icon">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="color-scheme" content="light dark">
+<title>DMSC Integration Testing</title>
+<script src="https://cdn.plot.ly/plotly-3.0.1.min.js" charset="utf-8"></script>
+<link rel="stylesheet" href="style.css">
+</head>
+<body style="font-family: Tahoma, sans-serif; border:0; margin:0;">
+    <div style="width: 100%; display: flex; height: 80px;">
+        <div style="flex:0.3;">
+            <img src="https://ess.eu/themes/custom/ess/logo.svg" alt="Logo" height="80">
+        </div>
+        <div style="flex:1; text-align: center; color: white; background-color: #0094ca;">
+            <h1><b>DMSC Integration Testing</b></h1>
+        </div>
+        <div style="flex:1; text-align:right; color: white; background-color: #0094ca;">
+            <h3>Last updated: {last_updated}</h3>
+        </div>
+    </div>
+    <div style="width: 100%;">
+        <table style="border-collapse: collapse;">
+            <tr>
+                <td style="width: 60%;vertical-align: top;">
+                    <br>
+                    Key: &nbsp;&nbsp;&nbsp;&nbsp; <div class='success' style='display:inline-block; width: 20px; height: 20px;'></div>
+                    = Success &nbsp;&nbsp;&nbsp;&nbsp; <div class='failed' style='display:inline-block; width: 20px; height: 20px;'></div>
+                    = Failed &nbsp;&nbsp;&nbsp;&nbsp; <div class='skipped' style='display:inline-block; width: 20px; height: 20px;'></div> = Skipped
+                    <br><br>
+                    <table style="border-collapse: collapse;">
+                        {tests_table}
+                    </table>
+                </td>
+                <td style=" width: 40%; vertical-align: top;">
+                    <div id="chart"></div>
+                    <div id="groups_chart"></div>
+                </td>
+            </tr>
+        </table>
+        <script>{plotly_script}</script>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This adds an automatic dark mode. The colours are determined based on the browser's `prefers-color-scheme` value. So it should generally adapt to user preference. I did not add a manual switcher because that would add extra complication. I can do that if people want it.

The plot colours aren't perfect because of the hacky colour filter that I used. Especially the text is a bit hard to read in dark mode. But fixing that requires some non-trivial javascript.

I also improved the style in some other ways:
- Added margin around content so it isn't glued to the window edges.
- Made the table header stick to the top of the page.
- Some alignment improvements (logo, legend).

To make this easier, I extracted the top-level, constant HTML and scripts into separate files. And I added a style sheet. That should make it easier to change behaviour and presentation separately.

![dashboard-dark](https://github.com/user-attachments/assets/86cc190e-8f22-4c8a-9ee8-f9c0b7010c39)
![dashboard-light](https://github.com/user-attachments/assets/17eacb88-30d2-499a-bac9-d4b42865bb49)
