### PR TITLE
Fix colour of error cells

### DIFF
--- a/render/style.css
+++ b/render/style.css
@@ -123,15 +123,16 @@ main {
     background: var(--success-bg-hover);
 }
 
-.failed {
+.failed, .error {
     background: var(--failed-bg);
 }
 
-.failed a, .failed a:visited {
+.failed a, .failed a:visited,
+.error a, .error a:visited {
     color: var(--failed-fg);
 }
 
-.failed:hover {
+.failed:hover, .error:hover {
     background: var(--failed-bg-hover);
 }
 
@@ -145,6 +146,17 @@ main {
 
 .skipped:hover {
     background: var(--skipped-bg-hover);
+}
+
+.error a:before {
+    content: '\f33b';
+    font-family:bootstrap-icons!important;
+    font-style:normal;
+    font-weight:400!important;
+    font-variant:normal;
+    line-height:1;
+    vertical-align:-.125em;
+    padding-right: 3pt;
 }
 
 /* make plots dark */

--- a/templates/main.html
+++ b/templates/main.html
@@ -8,6 +8,7 @@
 <meta name="color-scheme" content="light dark">
 <title>DMSC Integration Testing</title>
 <link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 <script src="https://cdn.plot.ly/plotly-3.0.1.min.js" charset="utf-8"></script>
 <script src="plot.js"></script>
 </head>


### PR DESCRIPTION
Jobs have two failure states, 'failed' and 'error'. We did not handle the 'error' state properly:
![broken](https://github.com/user-attachments/assets/6435e305-0bc4-4a8e-bbf3-7794ac582786)
This PR fixes that and also adds an icon to show that this is more serious than 'failure':
![fixed](https://github.com/user-attachments/assets/3dd07d4b-32cc-4835-b837-f795d164cf9f)
