### PR TITLE
change group name to pick up change in test name

### DIFF
--- a/render.py
+++ b/render.py
@@ -26,7 +26,7 @@ GROUPS = [
     "nexusfiles-scipp",
     "ingestor",
     "mcstas-scipp",
-    "nexusjsontemplate-beamlime",
+    "nexusjsontemplate-tests",
     "scipp-analysis",
     "scitacean",
 ]


### PR DESCRIPTION
As title.  Currently tests are blank for nexusjsontemplates, even thoguh they are processed in the Gitlab job correctly.