### PR TITLE
Only build dashboard once per day?

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Generate Dashboard
 on:
   workflow_dispatch:
   schedule:
-    - cron: "30 */3 * * *"  # At minute 30 past every 3rd hour
+    - cron: "0 5 * * *"  # Should run at 5am every day
 
 jobs:
   build:


### PR DESCRIPTION
I propose to build the dashboard only once per day, at 5am.
I don't think we need to render it every 3 hours.
If we really need to update it, we can do so manually but running the workflow from the GH interface.